### PR TITLE
UI and validation updates

### DIFF
--- a/src/components/__global__/ToastMessage.tsx
+++ b/src/components/__global__/ToastMessage.tsx
@@ -2,17 +2,20 @@ import { ToastContainer } from "react-fox-toast"
 
 const style = {
     padding: '.5rem .8rem',
-    fontSize: '.75rem'
+    fontSize: '.8rem '
 }
 
 const ToastMessage = () => {
     return (
-        <ToastContainer toastTypeTheming={{
-            success: { style, className: '' },
-            error: { style, className: '' },
-            info: { style, className: '' },
-            custom: { style, className: '' },
-        }} />
+        <ToastContainer
+            toastTypeTheming={{
+                success: { style, className: '' },
+                error: { style, className: '' },
+                info: { style, className: '' },
+                custom: { style, className: '' },
+            }}
+            position="bottom-left"
+        />
     )
 }
 

--- a/src/lib/hooks/newsletter.tsx
+++ b/src/lib/hooks/newsletter.tsx
@@ -28,36 +28,45 @@ export function useSubscribeToNewsletter() {
         loading,
         subscribeToNewsletter: async (event: FormEvent<HTMLFormElement>) => {
 
-            setLoading(true)
+            try {
 
-            event.preventDefault()
+                setLoading(true)
 
-            const data = getData(event.currentTarget)
-            const validationResult = subsciptionSchema.safeParse(data)
+                event.preventDefault()
 
-            if (validationResult.error) {
-                for (let error of validationResult.error.errors) {
-                    toast.warning(error.message)
+                const data = getData(event.currentTarget)
+                const validationResult = subsciptionSchema.safeParse(data)
+
+                if (validationResult.error) {
+
+                    for (let error of validationResult.error.errors) {
+                        toast.error(error.message)
+                    }
+
+                    setLoading(false)
+                    return
                 }
-                return
+
+                // Save to firebase
+                const saved = await saveASubscriber(data as CreateSubscriptionType)
+
+                if (!saved) {
+                    toast.error("Erreur, donnée non sauvegardée, réessayez !")
+                    return
+                }
+
+                // store in the local storage
+                saveToLocalStorage(LOCAL_STORAGE_KEYS.SUBSCRIPTION_DATA, saved)
+
+                // Success toast message
+                toast.success("Merci de vous être abonnés !")
+
+            } catch {
+                toast.error("Une erreur est survenue, réessayez !")
+            } finally {
+                // Reset the loading state
+                setLoading(false)
             }
-
-            // Save to firebase
-            const saved = await saveASubscriber(data as CreateSubscriptionType)
-
-            if (!saved) {
-                toast.error("Erreur, donnée non sauvegardée, réessayez !")
-                return
-            }
-
-            // store in the local storage
-            saveToLocalStorage(LOCAL_STORAGE_KEYS.SUBSCRIPTION_DATA, saved)
-
-            // Success toast message
-            toast.success("Merci de vous être abonnés !")
-
-            // Reste the loading state
-            setLoading(false)
 
         }
     }

--- a/src/lib/validation/subscription.schema.ts
+++ b/src/lib/validation/subscription.schema.ts
@@ -1,7 +1,7 @@
 import { z as zod } from "zod";
 
 const subsciptionSchema = zod.object({
-    contact: zod.string().email("Email invalide !").or(
+    contact: zod.string().email("Donnée de contact invalide : email ou numéro !").or(
         zod.string().regex(/^(?:\d{10}|\+\d{1,4}-\d{6,14})$/, "Numéro de téléphone invalide !")
     ),
     isEmail: zod.boolean()


### PR DESCRIPTION
- on invalid contact data, instead of toast.warning use toast.error so the custom style takes effect
- wrap the subscribeToNewsletter function content of the useSubscribeToNewsletter hook into a try-catch so we can handle errors and reset the loading state in the finally block